### PR TITLE
Make TTY broadcasts protected

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,6 +24,8 @@
 
     <original-package android:name="com.android.phone" />
 
+    <protected-broadcast android:name="android.telecom.action.TTY_PREFERRED_MODE_CHANGED" />
+    <protected-broadcast android:name="android.telecom.action.CURRENT_TTY_MODE_CHANGED" />
     <protected-broadcast android:name="android.intent.action.SERVICE_STATE" />
     <protected-broadcast android:name="android.intent.action.RADIO_TECHNOLOGY" />
     <protected-broadcast android:name="android.intent.action.EMERGENCY_CALLBACK_MODE_CHANGED" />


### PR DESCRIPTION
Currently, any app can broadcast the intent to update the TTY mode. This
change updates the intents to protected broadcasts so that only system
can broadcast them. Otherwise, a SecurityException will be thown.

Bug: 29832693
Change-Id: Ic9a91be3d8d15043e3165b766348cff301dd5da1
Signed-off-by: bgos10 bgos10@yahoo.co.in
